### PR TITLE
Fix Bug in win check for gameType divided_screen

### DIFF
--- a/gamearea.py
+++ b/gamearea.py
@@ -356,12 +356,20 @@ class GameArea(Gtk.DrawingArea):
                 catsCount[cat.cat_id-1]+=1
 
             for cat in self.cats:
-                if cat.x < alloc.width // 2 and catsCount[cat.cat_id-1] % 2 != 0:
-                    correctly_placed = False
-                    break
-                if cat.x > alloc.width // 2 and catsCount[cat.cat_id-1] % 2 == 0:
-                    correctly_placed = False
-                    break
+                if self.sides[0] == SideType.ODD:
+                    if cat.x < alloc.width // 2 and catsCount[cat.cat_id-1] % 2 == 0 :
+                        correctly_placed = False
+                        break
+                    if cat.x > alloc.width // 2 and catsCount[cat.cat_id-1] % 2 != 0:
+                        correctly_placed = False
+                        break
+                else:
+                    if cat.x < alloc.width // 2 and catsCount[cat.cat_id-1] % 2 != 0:
+                        correctly_placed = False
+                        break
+                    if cat.x > alloc.width // 2 and catsCount[cat.cat_id-1] % 2 == 0:
+                        correctly_placed = False
+                        break
 
             if correctly_placed:
                 message = _("You correctly placed the cats!")


### PR DESCRIPTION
Steps to reproduce:

1.  Play the gametype of correclty placing the cats, which is divided_screen
2.  In that gameType when the oddCats are to be placed to the left, Even if you place the cats correctly you won't have a win.

Reason:
It was checking for the evenCats on the left even though oddCats are to be checked.